### PR TITLE
fix: replace hardcoded project with the project variable

### DIFF
--- a/R/subset.R
+++ b/R/subset.R
@@ -82,7 +82,7 @@ armadillo.subset <- function(source_project = NULL,
   type <- folder <- . <- NULL
 
   suppressMessages(
-    source_tables <- within(armadillo.list_tables("gecko") %>%
+    source_tables <- within(armadillo.list_tables(source_project) %>%
                               str_split("/", simplify = TRUE) %>%
                               as_tibble(.name_repair = "unique") %>%
                               set_names("project", "folder", "table") %>%

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,6 @@
-## 2.1.9 Bugfixes
+## 2.1.11 Bugfixes
 * Update github pages using CI
+* Fix #98 Cannot create subsets for projects other than "gecko"
 * Fix #79 load_table function doesn't show error messages
 
 ## 2.1.2 Subset function and bugfixes


### PR DESCRIPTION
closes #98

To test:
Run armadillo on localhost. Make sure the demo project lifecycle is in there with its demo data as in the armadillo repo.
Download this file: 
[vars.csv](https://github.com/molgenis/molgenis-r-armadillo/files/13345884/vars.csv)

It contains the subset definition as in the demo code for the "lifecycle" test project. 
Create the subset definition:
``` R
subset_definition <- armadillo.subset_definition(vars ="path/to/vars.csv")
armadillo.subset(source_project = "lifecycle", new_project = "study1", subset_def = subset_definition, dry_run = FALSE)
```
Go to localhost and see study 1 is there with in the "core" folder the "nonrep" and "yearlyrep" and in "outcome" only "yearlyrep"

